### PR TITLE
Added styling to .timezone + .isp

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -124,6 +124,8 @@ span {
 }
 
 .ip,
+.timezone,
+.isp,
 .location {
   display: grid;
   grid-template-rows: 0.4fr 1fr;


### PR DESCRIPTION
Lat och long var inte med på stylingparagrafen för locationvärdena. Lade till dem där, så fick de samma spacing.
